### PR TITLE
Updated registration error messages and verification parameters

### DIFF
--- a/app/src/main/java/tcss450/uw/edu/chapp/RegisterFragment.java
+++ b/app/src/main/java/tcss450/uw/edu/chapp/RegisterFragment.java
@@ -1,6 +1,7 @@
 package tcss450.uw.edu.chapp;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -15,6 +16,9 @@ import android.widget.TextView;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import tcss450.uw.edu.chapp.model.Credentials;
 import tcss450.uw.edu.chapp.utils.SendPostAsyncTask;
 
@@ -27,8 +31,6 @@ import tcss450.uw.edu.chapp.utils.SendPostAsyncTask;
  */
 public class RegisterFragment extends Fragment {
 
-    public static final int MINIMUM_PASSWORD_SIZE = 6;
-
     private OnRegisterFragmentInteractionListener mListener;
     private Credentials mCredentials;
 
@@ -38,6 +40,12 @@ public class RegisterFragment extends Fragment {
 
     public void validateRegisterCredentials(View v) {
         // Fetch Values
+        Resources res = getContext().getResources();
+        int minPasswordSize = res.getInteger(R.integer.reg_password_min_chars);
+        int maxPasswordSize = res.getInteger(R.integer.reg_password_max_chars);
+        int minUsernameSize = res.getInteger(R.integer.reg_username_min_chars);
+        int maxUsernameSize = res.getInteger(R.integer.reg_username_max_chars);
+
         EditText emailEditText = getActivity().findViewById(R.id.field_email_register);
         EditText passwordEditText = getActivity().findViewById(R.id.field_password_register);
         EditText passwordConfirmEditText = getActivity().findViewById(R.id.field_password_register_confirm);
@@ -54,28 +62,61 @@ public class RegisterFragment extends Fragment {
 
         // Validate
         boolean emailEmpty = "".equals(email);
-        boolean passwordEmpty = "".equals(password);
-        boolean passwordConfirmEmpty = "".equals(passwordConfirm);
+
         boolean firstNameEmpty = "".equals(firstName);
         boolean lastNameEmpty = "".equals(lastName);
+
         boolean userNameEmpty = "".equals(userName);
-        boolean passwordTooShort = password.length() < MINIMUM_PASSWORD_SIZE;
-        boolean passwordConfirmTooShort = passwordConfirm.length() < MINIMUM_PASSWORD_SIZE;
+        boolean userNameTooShort = userName.length() < minUsernameSize;
+        boolean userNameTooLong = userName.length() > maxUsernameSize;
+
+        boolean passwordEmpty = "".equals(password);
+        boolean passwordTooShort = password.length() < minPasswordSize;
+        boolean passwordTooLong = password.length() > maxPasswordSize;
         boolean passwordsMatch = password.equals(passwordConfirm);
+
+        boolean passwordHasSpecialChar = checkForSpecialChar(password);
+        boolean passwordHasNumber = false;
+        boolean passwordHasUpperCase = false;
+        boolean passwordHasLowerCase = false;
+
+        for (int i = 0; i < password.length(); i++) {
+            char ch = password.charAt(i);
+            if (Character.isDigit(ch)) {
+                passwordHasNumber = true;
+            } else if (Character.isLowerCase(ch)) {
+                passwordHasLowerCase = true;
+            } else if (Character.isUpperCase(ch)) {
+                passwordHasUpperCase = true;
+            }
+        }
+
+
+
+        boolean passwordConfirmEmpty = "".equals(passwordConfirm);
+
         // Check if the email has exactly a single @
         boolean moreThanOneAtInEmail = false;
         boolean atInEmail = false;
         for (char c : email.toCharArray()) {
             if (c == '@') {
-                if (atInEmail == true) {
+                if (atInEmail) {
                     moreThanOneAtInEmail = true;
                 }
                 atInEmail = true;
             }
         }
 
-        if (!emailEmpty && !passwordEmpty && !passwordConfirmEmpty && !passwordTooShort
-                && !passwordConfirmTooShort && !firstNameEmpty && !lastNameEmpty && !userNameEmpty) {
+
+        boolean registerValid = !emailEmpty && atInEmail && !moreThanOneAtInEmail
+                && !firstNameEmpty && !lastNameEmpty
+                && !userNameEmpty && !userNameTooShort && !userNameTooLong
+                && !passwordEmpty && !passwordTooShort && !passwordTooLong
+                && passwordsMatch && passwordHasSpecialChar && passwordHasNumber
+                && passwordHasUpperCase && passwordHasLowerCase
+                && !passwordConfirmEmpty;
+
+        if (registerValid) {
             // Successfully Verified (client side)!
             Credentials credentials = new Credentials.Builder(email, password)
                     .addFirstName(firstName)
@@ -89,54 +130,69 @@ public class RegisterFragment extends Fragment {
                     .appendPath(getString(R.string.ep_base_url))
                     .appendPath(getString(R.string.ep_register))
                     .build();
+
             // build the JSONObject
             JSONObject msg = credentials.asJSONObject();
             mCredentials = credentials;
             // instantiate and execute the AsyncTask.
             new SendPostAsyncTask.Builder(uri.toString(), msg)
-                    .onPreExecute(this::handleLoginOnPre)
-                    .onPostExecute(this::handleLoginOnPost)
+                    .onPreExecute(this::handleRegisterOnPre)
+                    .onPostExecute(this::handleRegisterOnPost)
                     .onCancelled(this::handleErrorsInTask)
                     .build().execute();
         } else {
             // notify of all problems
+            //email error messages
             if (emailEmpty) {
-                emailEditText.setError("Please enter an Email");
+                emailEditText.setError(getString(R.string.reg_error_email_empty));
             } else if (moreThanOneAtInEmail) {
-                emailEditText.setError("Too many @ symbols in Email");
+                emailEditText.setError(getString(R.string.reg_error_email_too_many_at));
             } else if (!atInEmail){
-                emailEditText.setError("@ symbol must be in Email");
+                emailEditText.setError(getString(R.string.reg_error_email_no_at));
             }
 
+            //password error messages
             if (passwordEmpty) {
-                passwordEditText.setError("Please enter a password");
-            } else if (passwordTooShort) {
-                passwordEditText.setError("Password must be at least " + MINIMUM_PASSWORD_SIZE
-                        + " characters");
+                passwordEditText.setError(getString(R.string.reg_error_password_empty));
+            } else if (passwordTooShort || passwordTooLong) {
+                passwordEditText.setError(getString(R.string.reg_error_password_outofbounds));
+            } else if (!passwordHasSpecialChar) {
+                passwordEditText.setError(getString(R.string.reg_error_password_nospecialchar));
+            } else if (!passwordHasNumber) {
+                passwordEditText.setError(getString(R.string.reg_error_password_no_number));
+            } else if (!passwordHasUpperCase) {
+                passwordEditText.setError(getString(R.string.reg_error_password_no_upper_case));
+            } else if (!passwordHasLowerCase) {
+                passwordEditText.setError(getString(R.string.reg_error_password_no_lower_case));
             } else if (!passwordsMatch) {
-                passwordEditText.setError("Passwords do not match");
+                passwordEditText.setError(getString(R.string.reg_error_password_doesnotmatch));
             }
 
+            //password confirm error messages
             if (passwordConfirmEmpty) {
-                passwordConfirmEditText.setError("Please enter a password");
-            } else if (passwordConfirmTooShort) {
-                passwordConfirmEditText.setError("Password must be at least " + MINIMUM_PASSWORD_SIZE
-                        + " characters");
+                passwordConfirmEditText.setError(getString(R.string.reg_error_password_confirm_empty));
             }
 
+            //first name error messages
             if (firstNameEmpty) {
-                firstNameEditText.setError("Please enter a first name");
+                firstNameEditText.setError(getString(R.string.reg_error_firstname_empty));
             }
 
+            //last name error messages
             if (lastNameEmpty) {
-                lastNameEditText.setError("Please enter a last name");
+                lastNameEditText.setError(getString(R.string.reg_error_lastname_empty));
             }
 
+            //user name error messages
             if (userNameEmpty) {
-                userNameEditText.setError("Please enter a user name");
+                userNameEditText.setError(getString(R.string.reg_error_username_empty));
+            } else if (userNameTooShort || userNameTooLong) {
+                userNameEditText.setError(getString(R.string.reg_error_username_outofbounds));
             }
         }
     }
+
+
 
 
     @Override
@@ -179,7 +235,7 @@ public class RegisterFragment extends Fragment {
     /**
      * Handle the setup of the UI before the HTTP call to the webservice.
      */
-    private void handleLoginOnPre() {
+    private void handleRegisterOnPre() {
         mListener.onWaitFragmentInteractionShow();
     }
 
@@ -188,12 +244,12 @@ public class RegisterFragment extends Fragment {
      * a JSON formatted String. Parse it for success or failure.
      * @param result the JSON formatted String response from the web service
      */
-    private void handleLoginOnPost(String result) {
+    private void handleRegisterOnPost(String result) {
         try {
             JSONObject resultsJSON = new JSONObject(result);
             boolean success =
                     resultsJSON.getBoolean(
-                            getString(R.string.keys_json_login_success));
+                            getString(R.string.keys_json_register_success));
 
             System.out.println(resultsJSON);
             if (success) {
@@ -201,11 +257,47 @@ public class RegisterFragment extends Fragment {
                 mListener.onRegisterSuccess(mCredentials);
                 mListener.onWaitFragmentInteractionHide();
                 return;
+
             } else {
-                //Login was unsuccessful. Don’t switch fragments and
+                //register was unsuccessful. Don’t switch fragments and
                 // inform the user
-                ((TextView) getView().findViewById(R.id.field_email_register))
-                        .setError("Register Unsuccessful");
+
+                //if we get here, then either the user name or the email already exists.
+                JSONObject errorJSON = resultsJSON.getJSONObject(getString(R.string.keys_json_register_error));
+                String errorDetail = errorJSON.getString(getString(R.string.keys_json_register_error_message));
+                String errorCode = errorJSON.getString(getString(R.string.keys_json_register_code));
+
+                //if the error code is the error code from the database that the key already exists
+                if(errorCode.equals(getString(R.string.reg_error_code_key_already_exists))) {
+                    //use regex to get the key and value from the errorDetail
+                    Pattern p = Pattern.compile(getString(R.string.reg_error_regex_detail), Pattern.CASE_INSENSITIVE);
+                    //Key (email)=(test@test) already exists.
+                    //Pattern p = Pattern.compile("\\((.*?)\\)=\\((.*?)\\)");
+                    Matcher m = p.matcher(errorDetail);
+                    if (m.find()) {
+                        //get regex groups
+                        String key = m.group(1);
+                        String value = m.group(2);
+                        String errorMessage = value + " " + key + " already exists";
+                        //if the key is the email, then set the error on the email
+                        if(key.equals("email")) {
+                            ((TextView) getView().findViewById(R.id.field_email_register))
+                                    .setError(errorMessage);
+                        }
+                        //if the key is the username, then set the error on the email
+                        else if(key.equals("username")) {
+                            ((TextView) getView().findViewById(R.id.field_user_name_register))
+                                    .setError(errorMessage);
+                        }
+                    }
+
+                } else { //if we get here, then the error is not the user name or email already existing.
+                    ((TextView) getView().findViewById(R.id.field_email_register))
+                            .setError("Register Unsuccessful");
+                }
+
+
+
             }
             mListener.onWaitFragmentInteractionHide();
         } catch (JSONException e) {
@@ -221,6 +313,25 @@ public class RegisterFragment extends Fragment {
     }
 
     /**
+     * private helper method that will check the string for the existance of a
+     * special character defined in register_values.xml
+     * @param string is the string to check for special characters
+     * @return boolean if the string has a special character
+     */
+    private boolean checkForSpecialChar(String string) {
+        String specialCharacters = getString(R.string.reg_password_special_chars);
+        boolean result = false;
+        for (int i = 0; i < specialCharacters.length(); i++) {
+            char specChar = specialCharacters.charAt(i);
+            if (string.contains(Character.toString(specChar))) {
+                result = true;
+            }
+        }
+        return result;
+    }
+
+
+    /**
      * This interface must be implemented by activities that contain this
      * fragment to allow an interaction in this fragment to be communicated
      * to the activity and potentially other fragments contained in that
@@ -234,3 +345,5 @@ public class RegisterFragment extends Fragment {
         void onRegisterSuccess(Credentials theCredentials);
     }
 }
+
+

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -25,5 +25,11 @@
     <string name="key_blog_post">osbornem_blog_post_information</string>
     <string name="key_set_list">osbornem_set_list_information</string>
 
+    <!-- register keys -->
+    <string name="keys_json_register_error">error</string>
+    <string name="keys_json_register_error_message">detail</string>
+    <string name="keys_json_register_success">success</string>
+    <string name="keys_json_register_code">code</string>
+
 
 </resources>

--- a/app/src/main/res/values/register_values.xml
+++ b/app/src/main/res/values/register_values.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="reg_password_max_chars">12</integer>
+    <integer name="reg_password_min_chars">6</integer>
+
+    <integer name="reg_username_max_chars">12</integer>
+    <integer name="reg_username_min_chars">6</integer>
+
+    <string name="reg_password_special_chars">~!@#$%^*()_+{}[]/\-+="',`</string>
+
+    <!-- Register Error Messages -->
+    <string name="reg_error_email_empty">Email can\'t be empty</string>
+    <string name="reg_error_email_too_many_at">Too many @ symbols in Email</string>
+    <string name="reg_error_email_no_at">\@ symbol must be in Email</string>
+
+    <string name="reg_error_firstname_empty">First Name can\'t be empty</string>
+    <string name="reg_error_lastname_empty">Last Name can\'t be empty</string>
+
+    <string name="reg_error_username_empty">Username can\'t be empty</string>
+    <string name="reg_error_username_outofbounds">Username must have 6 – 12 characters</string>
+
+    <string name="reg_error_password_empty">Password can\'t be empty</string>
+    <string name="reg_error_password_outofbounds">Password must have 6 – 12 characters</string>
+    <string name="reg_error_password_nospecialchar">Password must have a special character [~!@#$%^*()_+{}[]/\-+="']</string>
+    <string name="reg_error_password_no_number">Password must have a number 0 – 9</string>
+    <string name="reg_error_password_no_upper_case">Password must have an upper case letter</string>
+    <string name="reg_error_password_no_lower_case">Password must have a lower case letter</string>
+    <string name="reg_error_password_doesnotmatch">Passwords must match</string>
+
+    <string name="reg_error_password_confirm_empty">Password can\'t be empty</string>
+
+    <!-- regex which is designed to get a key error from the error message returned from the
+    end point. This regex returns 2 groups,
+     group 1 is the key
+     group 2 is the value -->
+    <string name="reg_error_regex_detail">\\((.*?)\\)=\\((.*?)\\)</string>
+    <string name="reg_error_code_key_already_exists">23505</string>
+
+</resources>


### PR DESCRIPTION
-Passwords now require at least one number, one lower case letter, one upper case letter, and one special character (defined in register_values.xml).
- username and password require between 6-12 characters
Relocated register error messages to register_values.xml

Extracted error message from backend:
- when the server tries to insert a new username or email and it already exists, then it will pass back an error JSONObject.
 * Register now extracts the error JSON object and tells the user why registration failed, such as username already exists or email already exists.