### PR TITLE
Mjosten nav drawer logout implemented

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,9 +3,6 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <compositeConfiguration>
-          <compositeBuild compositeDefinitionSource="SCRIPT" />
-        </compositeConfiguration>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">

--- a/app/src/main/java/tcss450/uw/edu/chapp/HomeActivity.java
+++ b/app/src/main/java/tcss450/uw/edu/chapp/HomeActivity.java
@@ -1,6 +1,7 @@
 package tcss450.uw.edu.chapp;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
@@ -91,7 +92,13 @@ public class HomeActivity extends AppCompatActivity
 
         // Set the logout listener for the navigation drawer
         TextView logoutText = (TextView) findViewById(R.id.nav_logout);
-        logoutText.setOnClickListener(this::onLogoutClick);
+        logoutText.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Log.d("CHAPP_LOGOUT", "Logout clicked in navigation bar");
+                logout();
+            }
+        });
     }
 
     @Override
@@ -192,14 +199,7 @@ public class HomeActivity extends AppCompatActivity
         drawer.closeDrawer(GravityCompat.START);
         return true;
     }
-    /**
-     * Logout click listener for the logout button in the navigation drawer
-     * TODO: logout the user
-     * @param theText the TextView that was pressed
-     */
-    public void onLogoutClick(View theText) {
-        Log.i("NAVIGATION_INFORMATION", "Pressed: " + ((TextView)theText).getText().toString());
-    }
+
 
     private void loadFragment(Fragment frag) {
         FragmentTransaction transaction = getSupportFragmentManager()
@@ -386,10 +386,10 @@ public class HomeActivity extends AppCompatActivity
         finishAndRemoveTask();
 
         //or close this activity and bring back the login
-        // Intent i = new Intent(this, MainActivity.class);
-        // startActivity(i);
+         //Intent i = new Intent(this, MainActivity.class);
+         //startActivity(i);
         // End this Activity and remove it form the Activity back stack.
-        // finish();
+         //finish();
     }
 
 

--- a/app/src/main/java/tcss450/uw/edu/chapp/HomeActivity.java
+++ b/app/src/main/java/tcss450/uw/edu/chapp/HomeActivity.java
@@ -126,10 +126,10 @@ public class HomeActivity extends AppCompatActivity
         int id = item.getItemId();
 
         //noinspection SimplifiableIfStatement
-        if (id == R.id.action_logout) {
-            logout();
-            return true;
-        }
+//        if (id == R.id.action_logout) {
+//            logout();
+//            return true;
+//        }
 
         return super.onOptionsItemSelected(item);
     }
@@ -383,13 +383,13 @@ public class HomeActivity extends AppCompatActivity
 
 
         //Close the app
-        finishAndRemoveTask();
+        //finishAndRemoveTask();
 
         //or close this activity and bring back the login
-         //Intent i = new Intent(this, MainActivity.class);
-         //startActivity(i);
+         Intent i = new Intent(this, MainActivity.class);
+         startActivity(i);
         // End this Activity and remove it form the Activity back stack.
-         //finish();
+         finish();
     }
 
 

--- a/app/src/main/res/menu/home.xml
+++ b/app/src/main/res/menu/home.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-    <item
-        android:id="@+id/action_logout"
-        android:orderInCategory="100"
-        android:title="@string/action_logout"
-        app:showAsAction="never" />
+    <!--<item-->
+        <!--android:id="@+id/action_logout"-->
+        <!--android:orderInCategory="100"-->
+        <!--android:title="@string/action_logout"-->
+        <!--app:showAsAction="never" />-->
 </menu>


### PR DESCRIPTION
Navigation drawer logout is implemented.
The behavior of logout is that the shared preferences are deleted and the user is directed to the sign in fragment rather than completely exiting the app.

- The logout button on the right side is commented out so it no longer appears in the app.